### PR TITLE
Optionally require tunnels by listening on 127.0.1.1

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -196,8 +196,13 @@ void start_button_clicked(GtkWidget *widget, gpointer data) {
         if(page == 0) {
             save_synergy_config(state);
 
-            argv = make_argv("synergys", "-f", "--config",
-                ".quicksynergy/synergy.conf", NULL);
+            if(state->data.req_tunnel) {
+                argv = make_argv("synergys", "-f", "-a", "127.0.1.1",
+                    "--config", ".quicksynergy/synergy.conf", NULL);
+            } else {
+                argv = make_argv("synergys", "-f", "--config",
+                    ".quicksynergy/synergy.conf", NULL);
+            }
 
             state->proc.running = SYNERGY_SERVER_RUNNING;
         }

--- a/src/state.h
+++ b/src/state.h
@@ -30,6 +30,7 @@ typedef struct qs_state {
         gchar *hostname;
         gchar *client_name;
         gboolean use_socks;
+        gboolean req_tunnel;
     } data;
 
     struct {

--- a/src/synergy_config.c
+++ b/src/synergy_config.c
@@ -62,6 +62,11 @@ qs_state_t *load_config() {
          g_key_file_get_value(key_file, "Share", "Right", NULL) :
          _("Right"));
 
+    state->data.req_tunnel =
+        (g_key_file_has_key(key_file, "Require", "Tunnel", NULL) ?
+         g_key_file_get_boolean(key_file, "Require", "Tunnel", NULL) :
+         0);
+
     state->data.hostname =
         (g_key_file_has_key(key_file, "Use", "Hostname", NULL) ?
          g_key_file_get_value(key_file, "Use", "Hostname", NULL) :
@@ -117,13 +122,16 @@ void save_config(qs_state_t *state) {
         g_key_file_set_value(key_file, "Share", "Right", state->data.right);
     }
 
+    g_key_file_set_boolean(key_file, "Require", "Tunnel",
+                           state->data.req_tunnel);
+
     g_key_file_set_value(key_file, "Use", "Hostname", state->data.hostname);
 
     g_key_file_set_value(key_file, "Use", "ClientName",
                          state->data.client_name);
 
     g_key_file_set_boolean(key_file, "Use", "SOCKS",
-                         state->data.use_socks);
+                           state->data.use_socks);
 
     g_key_file_set_integer(key_file, "Settings", "LastPage",
                            state->ui.current_page);

--- a/src/ui.c
+++ b/src/ui.c
@@ -54,6 +54,8 @@ GtkWidget *screen_entry_new(char **textp, const char *position) {
 }
 
 GtkWidget *make_server_tab(qs_state_t *state) {
+    GtkWidget *pane;
+    GtkWidget *checkbox;
     GtkWidget *table;
     GtkWidget *vbox;
     GtkWidget *image;
@@ -64,9 +66,12 @@ GtkWidget *make_server_tab(qs_state_t *state) {
     GtkWidget *right_entry;
     char hostname[64];
 
+    pane = gtk_vbox_new(FALSE, 18);
+    gtk_container_set_border_width(GTK_CONTAINER(pane), 12);
+
     /* build the table that will hold the server layout widgets */
     table = gtk_table_new(3, 3, TRUE);
-    gtk_container_set_border_width(GTK_CONTAINER(table), 12);
+    gtk_box_pack_start(GTK_BOX(pane), table, FALSE, FALSE, 0);
 
     /* text entries for server configuration */
     above_entry = screen_entry_new(&state->data.above, _("Above"));
@@ -94,7 +99,15 @@ GtkWidget *make_server_tab(qs_state_t *state) {
         gtk_box_pack_start(GTK_BOX(vbox), label,  FALSE, FALSE, 0);
     }
 
-    return table;
+    /* checkbox to require local/tunneled connections only */
+    checkbox = gtk_check_button_new_with_label(_("Tunneled only"));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbox), state->data.req_tunnel);
+    gtk_box_pack_start(GTK_BOX(pane), checkbox, FALSE, FALSE, 0);
+
+    g_signal_connect(G_OBJECT(checkbox), "toggled",
+        G_CALLBACK(checkbox_changed_cb), (gpointer) &state->data.req_tunnel);
+
+    return pane;
 }
 
 GtkWidget *make_client_tab(qs_state_t *state) {


### PR DESCRIPTION
This patch adds a "Tunneled only" checkbox to the "Share" pane, setting `synergys` to listen only on `127.0.1.1`, which is how SSH seems to handle tunneled connections (at least on my default Ubuntu configuration). I'd encourage testing to make sure that this works on others' machines.

I recognize that the point of quicksynergy is to largely eliminate the unnecessary options of synergy, but without something like this, it remains possible for users to have unintentionally unencrypted connections.